### PR TITLE
allow for behave 1.2.7.dev*

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-behave==1.2.6
+behave~=1.2.6
 prettytable
 reportportal-client~=5.5.7


### PR DESCRIPTION
why?

allows for project to use behave 1.2.7dev features like cucumber-tag-expressions https://behave.readthedocs.io/en/latest/new_and_noteworthy_v1.2.7/

risk?

If 1.2.7 is released, pip will install it by default. 
However given that 1.2.6 was released in 2018, seems probable that next release will be 1.3.0 (if a release actually occurs)

https://pypi.org/project/behave/#history

alternative?

release a dev version or fork with this change since there is risk and uncertainty