### PR TITLE
Handle Behave “error” Status as FAILED in ReportPortal

### DIFF
--- a/behave_reportportal/behave_agent.py
+++ b/behave_reportportal/behave_agent.py
@@ -521,6 +521,8 @@ class BehaveAgent(metaclass=Singleton):
             return "FAILED"
         elif behave_status == "skipped":
             return "SKIPPED"
+        elif behave_status == "error":
+            return "FAILED"
         else:
             # todo define what to do
             return "PASSED"


### PR DESCRIPTION
Handle Behave “error” Status as FAILED in ReportPortal ([Introduced in Behave 1.2.7](https://behave.readthedocs.io/en/latest/new_and_noteworthy_v1.2.7/#distinguish-between-failures-and-errors))

Behave 1.2.7 introduced a new result status called error, but ReportPortal doesn’t automatically interpret it.
Because of this, any scenario marked as error was previously reported as PASSED.

This update ensures that Behave’s error status is correctly mapped to FAILED in ReportPortal, preventing false positives and improving result accuracy.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error status reporting to correctly display test errors as failed in test reports.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->