### PR TITLE
Update reportportal-client version to 5.7.10

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 behave==1.3.3
 prettytable>=3.6.0, <=3.17.0
-reportportal-client==5.7.7
+reportportal-client==5.7.10


### PR DESCRIPTION
Update reportportal-client from 5.7.7 to 5.7.10.

This allows the Behave integration to work with the latest aiohttp 3.14.x patch release while retaining the existing dependency structure.

Tests:
- `AGENT_NO_ANALYTICS=1 pytest tests/units/` (101 passed)

— sent via Glean Desktop

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the ReportPortal integration to version 5.7.10.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->